### PR TITLE
Rename to utils, make exports semantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# Superhero Button
+# Superhero Utils
 
 ## Installation
 
 You can get it as npm package or from the unpkg.com.
 
 ### With npm
-- run `$ npm install @aeternity/superhero-button --save` in the root or your project
-- import this package by `import superheroButton from '@aeternity/superhero-button';`
+- run `$ npm install @aeternity/superhero-utils --save` in the root or your project
+- import this package by `import superheroUtils from '@aeternity/superhero-utils';`
 
 ### With unpkg.com and `<script>` tag
 Add this to your website's HTML:
 ```html
-<script src="https://unpkg.com/@aeternity/superhero-button@0.3.0/dist/superhero-button.styles.js"></script>
+<script src="https://unpkg.com/@aeternity/superhero-utils@0.3.0/dist/index.js"></script>
 ```
-This will define `superheroButton` in the global scope.
+This will define `superheroUtils` in the global scope.
 
 ### With custom styles
-You can import and process styles manually by importing `dist/style.css` and
-`dist/superhero-button.js` separately. Or even you can don't import styles at
+You can import and process styles manually by importing `dist/index.css` and
+`dist/index-without-styles.js` separately. Or even you can don't import styles at
 all, and write your own instead.
 
 ## Usage
 
-### Button (`superheroButton`)
+### Button (`superheroUtils.createButton`)
 This library exports a function that creates buttons. This function accepts arguments:
 - class name of nodes that should become buttons, or the DOM node itself
   (this option simplifies integration into Frontend frameworks like Vue/React)
@@ -39,7 +39,7 @@ Option | Description
 ```html
 <div class="my-button">Donate</div>
 <script type="text/javascript">
-  superheroButton('.my-button', {
+  superheroUtils.createButton('.my-button', {
     size: 'large',
     account: 'example.chain',
     url: 'https://example.com',
@@ -58,7 +58,7 @@ Size value | Screenshot
 `medium` | <img width="203" alt="medium" src="https://user-images.githubusercontent.com/13139371/81780936-0256c100-9500-11ea-960e-9256a941285d.png">
 `large` | <img width="140" alt="large" src="https://user-images.githubusercontent.com/13139371/81780943-0387ee00-9500-11ea-8108-2e5939821a7b.png">
 
-### Paywall (`superheroButton.ensurePayed`)
+### Paywall (`superheroUtils.ensurePayed`)
 This function asks the user to send a tip to the specified page. It won't ask to send a
 tip if it was sent before using the current browser. The function accepts options object.
 
@@ -70,7 +70,7 @@ Option | Description
 
 ```html
 <script type="text/javascript">
-  superheroButton.ensurePayed({ url: 'https://example.com' });
+  superheroUtils.ensurePayed({ url: 'https://example.com' });
 </script>
 ```
 Additional examples can be found [here](./index.html).

--- a/index.html
+++ b/index.html
@@ -22,29 +22,29 @@
 <p>Sed eu convallis nisi. Proin aliquam diam eget risus venenatis pharetra. Sed varius commodo mauris eu accumsan. Donec erat tellus, vestibulum in efficitur non, aliquet eu leo. Aenean bibendum risus leo, ac consequat urna gravida ut. Proin ut justo eget ligula tempor euismod. Sed nec dui at est tristique ultrices et eu massa.</p>
 <p>Suspendisse ut tempus nibh. Fusce placerat neque lacinia mi mattis hendrerit. Phasellus blandit sit amet nibh sed molestie. Praesent vulputate imperdiet mauris vitae lobortis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Mauris in tellus lacinia, imperdiet diam sit amet, porta nisl. In vehicula in elit ac dignissim. Curabitur vehicula sollicitudin molestie. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec convallis non odio a commodo.</p>
 
-<script src="dist/superhero-button.styles.js"></script>
+<script src="dist/index.js"></script>
 <script>
 /*
 * Create superhero button instance by pointing element with its selector
 */
-superheroButton('.icon', { size: 'icon', account: 'ak_... or .chain name' });
-superheroButton('.small', { size: 'small', account: 'ak_... or .chain name' });
-superheroButton('.medium', { size: 'medium', account: 'ak_... or .chain name' });
+superheroUtils.createButton('.icon', { size: 'icon', account: 'ak_... or .chain name' });
+superheroUtils.createButton('.small', { size: 'small', account: 'ak_... or .chain name' });
+superheroUtils.createButton('.medium', { size: 'medium', account: 'ak_... or .chain name' });
 
 /*
 * Create superhero button instance by passing DOM element instance
 */
-superheroButton(document.querySelector('.large'), { size: 'large', account: 'ak_... or .chain name' });
+superheroUtils.createButton(document.querySelector('.large'), { size: 'large', account: 'ak_... or .chain name' });
 
 // Initialize button a.superhero-tip-button appears dynamically
 setTimeout(function() {
   var btn = document.createElement("div");
   document.body.appendChild(btn);
-  superheroButton(btn);
+  superheroUtils.createButton(btn);
 }, 5000);
 
 document.querySelector('.ensure-payed')
-    .addEventListener('click', () => superheroButton.ensurePayed());
+    .addEventListener('click', () => superheroUtils.ensurePayed());
 
 document.querySelector('.reset-payed-state')
     .addEventListener('click', () => delete localStorage['superhero-paywall-payed-urls']);

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@aeternity/superhero-button",
+  "name": "@aeternity/superhero-utils",
   "version": "0.3.0",
   "description": "",
-  "main": "dist/superhero-button.styles.js",
-  "browser": "dist/superhero-button.styles.js",
+  "main": "dist/index.js",
+  "browser": "dist/index.js",
   "dependencies": {},
   "files": [
     "dist",
@@ -35,12 +35,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aeternity/superhero-button.git"
+    "url": "git+https://github.com/aeternity/superhero-utils.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/aeternity/superhero-button/issues"
+    "url": "https://github.com/aeternity/superhero-utils/issues"
   },
-  "homepage": "https://github.com/aeternity/superhero-button#readme"
+  "homepage": "https://github.com/aeternity/superhero-utils#readme"
 }

--- a/src/button/index.js
+++ b/src/button/index.js
@@ -47,7 +47,7 @@ const createButtonInstance = ({ size = 'icon', url = window.location.href, accou
   if (!templates[size]) throw new Error('Unsupported size');
   const button = document.createElement('div');
   button.innerHTML = templates[size];
-  button.className = `superhero-button-2 ${size}`;
+  button.className = `superhero-utils-button ${size}`;
 
   (async () => {
     const tipsEl = button.querySelector('.tips');

--- a/src/button/index.scss
+++ b/src/button/index.scss
@@ -1,6 +1,6 @@
 @use '../variables';
 
-.superhero-button-2 {
+.superhero-utils-button {
   padding: 0;
   border: none;
   background: transparent;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
 import './global.scss';
-import { default as createButton } from './button';
-import { default as ensurePayed } from './paywall';
-
-Object.assign(createButton, { ensurePayed });
-
-export default createButton;
+export { default as createButton } from './button';
+export { default as ensurePayed } from './paywall';

--- a/src/paywall/index.js
+++ b/src/paywall/index.js
@@ -25,7 +25,7 @@ export default async ({ url = removeWalletResponse(window.location.href) } = {})
   if (getPayedUrls().includes(url)) return;
 
   const overlay = document.createElement('div');
-  overlay.className = 'superhero-paywall';
+  overlay.className = 'superhero-utils-paywall';
   overlay.innerHTML = `
     <div class="modal">
       You need to leave a tip to continue

--- a/src/paywall/index.scss
+++ b/src/paywall/index.scss
@@ -1,6 +1,6 @@
 @use '../variables';
 
-.superhero-paywall {
+.superhero-utils-paywall {
   display: flex;
   position: fixed;
   top: 0;
@@ -20,7 +20,7 @@
     border-radius: variables.$border-radius;
     text-align: center;
 
-    .superhero-button-2 {
+    .superhero-utils-button {
       margin-top: 1rem;
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,7 @@ const genConfig = (filename, { inlineCss } = {}) => ({
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename,
-    library: 'superheroButton',
-    libraryExport: 'default',
+    library: 'superheroUtils',
     libraryTarget: 'umd'
   },
   target: 'web',
@@ -33,12 +32,12 @@ const genConfig = (filename, { inlineCss } = {}) => ({
     ]
   },
   plugins: [
-    ...inlineCss ? [] : [new MiniCssExtractPlugin({ filename: 'style.css' })],
+    ...inlineCss ? [] : [new MiniCssExtractPlugin({ filename: 'index.css' })],
     new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: [] }),
   ],
 });
 
 module.exports = [
-  genConfig('superhero-button.js'),
-  genConfig('superhero-button.styles.js', { inlineCss: true }),
+  genConfig('index-without-styles.js'),
+  genConfig('index.js', { inlineCss: true }),
 ];


### PR DESCRIPTION
I did these changes at the same time as #24. This PR proposes to rename the package, repository, and to rearrange exports in a more obvious way.