### PR TITLE
Fix typo: payed -> paid

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Size value | Screenshot
 `medium` | <img width="203" alt="medium" src="https://user-images.githubusercontent.com/13139371/81780936-0256c100-9500-11ea-960e-9256a941285d.png">
 `large` | <img width="140" alt="large" src="https://user-images.githubusercontent.com/13139371/81780943-0387ee00-9500-11ea-8108-2e5939821a7b.png">
 
-### Paywall (`superheroUtils.ensurePayed`)
+### Paywall (`superheroUtils.ensurePaid`)
 This function asks the user to send a tip to the specified page. It won't ask to send a
 tip if it was sent before using the current browser. The function accepts options object.
 
@@ -70,7 +70,7 @@ Option | Description
 
 ```html
 <script type="text/javascript">
-  superheroUtils.ensurePayed({ url: 'https://example.com' });
+  superheroUtils.ensurePaid({ url: 'https://example.com' });
 </script>
 ```
 Additional examples can be found [here](./index.html).

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <div class="large">Donate</div>
 
 <hr>
-<button class="ensure-payed">Ensure payed</button>
-<button class="reset-payed-state">Reset payed state</button>
+<button class="ensure-paid">Ensure paid</button>
+<button class="reset-paid-state">Reset paid state</button>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum in ligula sit amet libero blandit laoreet luctus scelerisque eros. Donec nunc tortor, condimentum eu imperdiet ac, ornare ac leo. Nullam non nulla non massa hendrerit tempus. Donec imperdiet euismod lacus eu commodo. In pellentesque ipsum sed mi iaculis vestibulum. Mauris quis blandit est. Ut lacinia quam sit amet dapibus pellentesque. Donec pretium at erat sed elementum.</p>
 <p>Cras vitae erat at sapien pretium scelerisque at a odio. Aenean pulvinar tellus sit amet posuere porta. Sed vel efficitur nisl, a sollicitudin enim. Quisque eu velit id leo interdum ultrices. Nam vulputate lectus nec neque efficitur lobortis. In vehicula leo id ligula varius, ac lobortis lorem dictum. Proin dignissim lobortis massa, non facilisis nisi auctor vel. Praesent eget molestie mauris, vel vehicula velit. In hac habitasse platea dictumst. Aenean molestie blandit pulvinar.</p>
 <p>Vestibulum finibus sagittis nulla nec scelerisque. Duis libero dui, viverra vitae ipsum sit amet, congue lacinia lorem. Etiam porta quis nisi ut consequat. In hac habitasse platea dictumst. Nunc dapibus condimentum tempor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse non erat vitae velit semper elementum. Donec eleifend dictum dui, in ultrices nisi lobortis id. Integer sit amet luctus mauris. Vivamus a lacus non augue pulvinar dapibus in a neque. Morbi semper convallis justo quis aliquam. Cras at blandit felis, at porta magna. Maecenas egestas purus purus, vel fringilla massa iaculis eu. In at eleifend quam. Nulla vitae metus ex. Nunc eu augue ut sem tincidunt volutpat vitae ac orci.</p>
@@ -43,9 +43,9 @@ setTimeout(function() {
   superheroUtils.createButton(btn);
 }, 5000);
 
-document.querySelector('.ensure-payed')
-    .addEventListener('click', () => superheroUtils.ensurePayed());
+document.querySelector('.ensure-paid')
+    .addEventListener('click', () => superheroUtils.ensurePaid());
 
-document.querySelector('.reset-payed-state')
-    .addEventListener('click', () => delete localStorage['superhero-paywall-payed-urls']);
+document.querySelector('.reset-paid-state')
+    .addEventListener('click', () => delete localStorage['superhero-paywall-paid-urls']);
 </script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import './global.scss';
 export { default as createButton } from './button';
-export { default as ensurePayed } from './paywall';
+export { default as ensurePaid } from './paywall';
+

--- a/src/paywall/index.js
+++ b/src/paywall/index.js
@@ -1,7 +1,7 @@
-import './index.scss';
 import createButton from '../button';
+import './index.scss';
 
-const localStorageKey = 'superhero-paywall-payed-urls';
+const localStorageKey = 'superhero-paywall-paid-urls';
 const urlResult = 'superhero-paywall-tip-result';
 const urlParamSuccess = 'success';
 
@@ -11,18 +11,18 @@ const removeWalletResponse = url => {
   return u.toString();
 }
 
-const getPayedUrls = () => localStorage[localStorageKey] ? JSON.parse(localStorage[localStorageKey]) : [];
+const getPaidUrls = () => localStorage[localStorageKey] ? JSON.parse(localStorage[localStorageKey]) : [];
 
-const markUrlAsPayed = (url) => {
-  const payedUrls = getPayedUrls();
-  if (payedUrls.includes(url)) return;
-  payedUrls.push(url);
-  localStorage[localStorageKey] = JSON.stringify(payedUrls);
+const markUrlAsPaid = (url) => {
+  const paidUrls = getPaidUrls();
+  if (paidUrls.includes(url)) return;
+  paidUrls.push(url);
+  localStorage[localStorageKey] = JSON.stringify(paidUrls);
 }
 
 export default async ({ url = removeWalletResponse(window.location.href) } = {}) => {
-  if (new URL(window.location).searchParams.get(urlResult) === urlParamSuccess) markUrlAsPayed(url);
-  if (getPayedUrls().includes(url)) return;
+  if (new URL(window.location).searchParams.get(urlResult) === urlParamSuccess) markUrlAsPaid(url);
+  if (getPaidUrls().includes(url)) return;
 
   const overlay = document.createElement('div');
   overlay.className = 'superhero-utils-paywall';


### PR DESCRIPTION
This PR fixes all the occurrences of `payed` and replaces them with the more accurate word `paid`.

This will break API backward compatibility.