### PR TITLE
npm: bump version 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aeternity/superhero-utils",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "dist/index.js",
   "browser": "dist/index.js",


### PR DESCRIPTION
The package published under `0.5.0` is not containing the `dist` folder.

Npm does not allow `npm publish -f` to overwrite a package with the same version, thus I'm bumping the version in order to push the fixed one in npm.